### PR TITLE
Add Data Manager for fetching Cornell Days Events

### DIFF
--- a/CampusTour/Data/DataManager.swift
+++ b/CampusTour/Data/DataManager.swift
@@ -1,0 +1,60 @@
+//
+//  DataManager.swift
+//  CampusTour
+//
+//  Created by Annie Cheng on 4/4/18.
+//  Copyright © 2018 cuappdev. All rights reserved.
+//
+
+import Foundation
+
+// Data Manager for handling the Cornell Days Data
+public class DataManager {
+    
+    // Gives a shared instance of `DataManager`
+    public static let sharedInstance = DataManager()
+    
+    // List of all composite events
+    private (set) public var compositeEvents: [CompositeEvent] = []
+    
+    // List of all individual events
+    private (set) public var events: [Event] = []
+    
+    // Get a list of composite events
+    public func getCompositeEvents(completion: @escaping ((_ success: Bool) -> Void)) {
+        let eventsUrlString = "https://schedule.cornelldays.cornell.edu/api/itin/cornelldays/events/"
+        guard let url = URL(string: eventsUrlString) else { return }
+        
+        URLSession.shared.dataTask(with: url) { (data, response, _) in
+            guard let data = data else { return }
+            
+            do {
+                let compEvents = try JSONDecoder().decode(CompositeEvents.self, from: data)
+                self.compositeEvents = compEvents.events
+                completion(true)
+            } catch let error {
+                print("JSON Serialization Error: ", error)
+                completion(false)
+            }
+            }.resume()
+    }
+    
+    // Get a list of individual events
+    public func getEvents(compEvents: [CompositeEvent]) {
+        var singleEvents: [Event] = []
+        
+        for event in compEvents {
+            for time in event.times {
+                let name = "\(event.title): \(time.note)"
+                let locationName = (time.locationName != "") ? time.locationName : event.locationName
+                let location = Location(name: locationName, lat: nil, lng: nil)
+                let startTime = time.startTime.toDate(dateFormat: "MMMM, d yyyy HH:mm:ss")
+                let endTime = time.endTime.toDate(dateFormat: "MMMM, d yyyy HH:mm:ss")
+                let singleEvent = Event(id: time.id, compEventId: event.id, name: name, description: event.description, startTime: startTime, endTime: endTime, location: location, college: nil, type: nil, tags: event.tags)
+                singleEvents.append(singleEvent)
+            }
+        }
+        
+        events = singleEvents
+    }
+}

--- a/CampusTour/Data/EventData.swift
+++ b/CampusTour/Data/EventData.swift
@@ -1,0 +1,117 @@
+//
+//  EventData.swift
+//  CampusTour
+//
+//  Created by Annie Cheng on 4/4/18.
+//  Copyright © 2018 cuappdev. All rights reserved.
+//
+
+import Foundation
+
+struct EventTag: Decodable {
+    let id: String
+    let label: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case id = "TAG_ID"
+        case label = "TAG_LABEL"
+    }
+}
+
+struct EventTime: Decodable {
+    let id: String
+    let startTime: String
+    let endTime: String
+    let locationName: String
+    let note: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case id = "TIME_ID"
+        case startTime = "TIME_START"
+        case endTime = "TIME_END"
+        case locationName = "TIME_LOCATION_OVERRIDE"
+        case note = "TIME_NOTE"
+    }
+}
+
+public struct CompositeEvent: Decodable {
+    let tags: [EventTag]
+    let externalRegistrationUrl: String
+    let times: [EventTime]
+    let description: String
+    let id: String
+    let additionalFee: String
+    let externalUrl: String
+    let title: String
+    let locationName: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case tags = "EVENT_TAGS"
+        case externalRegistrationUrl = "EVENT_EXTERNAL_REGISTRATION_URL"
+        case times = "EVENT_TIMES"
+        case description = "EVENT_DESCRIPTION"
+        case id = "EVENT_ID"
+        case additionalFee = "EVENT_ADDITIONAL_FEE"
+        case externalUrl = "EVENT_EXTERNAL_URL"
+        case title = "EVENT_TITLE"
+        case locationName = "EVENT_LOCATION"
+    }
+}
+
+struct Meta: Decodable {
+    let eventStatus: String
+    let filterTags: String
+    let numEvents: Int
+    let requestTime: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case eventStatus = "EVENT_STATUS"
+        case filterTags = "FILTER_TAGS"
+        case numEvents = "NUM_EVENTS"
+        case requestTime = "REQUESTTIME"
+    }
+}
+
+struct CompositeEvents: Decodable {
+    let events: [CompositeEvent]
+    let meta: Meta
+    
+    private enum CodingKeys: String, CodingKey {
+        case events = "EVENTS"
+        case meta = "META"
+    }
+}
+
+struct Location {
+    let name: String?
+    let lat: Float?
+    let lng: Float?
+}
+
+enum EventType {
+    case Orientation
+    case Meals
+}
+
+enum College {
+    case ArtsScience
+    case Engineering
+    case ILR
+    case CALS
+    case Hotel
+    case AAP
+    case HumanEcology
+}
+
+public struct Event {
+    let id: String
+    let compEventId: String?
+    let name: String
+    let description: String
+    let startTime: Date
+    let endTime: Date
+    let location: Location
+    let college: College?
+    let type:  EventType?
+    let tags: [EventTag]
+}

--- a/CampusTour/Data/TestData.swift
+++ b/CampusTour/Data/TestData.swift
@@ -11,13 +11,17 @@ import UIKit
 
 let testEvents: [Event] = Array(
     repeating: Event(
+        id: "123",
+        compEventId: "234",
         name: "AppDev Workshop",
-        description: "Cool React workdshop!",
-        location: Location.init(longitude: 0, latitude: 0),
+        description: "Cool React workshop!",
+        startTime: Date(timeIntervalSinceNow: 1000),
+        endTime: Date(timeIntervalSinceNow: 2000),
+        location: Location(name: "Olin Hall 155", lat: 0, lng: 0),
         college: College.Engineering,
         type: EventType.Orientation,
-        time: Date(timeIntervalSinceNow: 1000)),
-    count: 3)
+        tags: []
+    ), count: 3)
 
 let testPlaces: [Building] = Array(
     repeating: Building(
@@ -25,5 +29,7 @@ let testPlaces: [Building] = Array(
         name: "Gates Hall",
         department: "CIS",
         icon: UIImage(), //TODO change to url
-        location: Location(longitude: 42.444953, latitude: -76.480973)),
-    count: 20)
+        location: Location(name: "Gates Hall", lat: -76.480973, lng: 42.444953)
+    ), count: 20)
+
+

--- a/CampusTour/Data/TourData.swift
+++ b/CampusTour/Data/TourData.swift
@@ -8,41 +8,6 @@
 
 import UIKit
 
-enum EventType {
-    //Type of events
-    case Orientation
-    case Meals
-}
-
-enum College {
-    case ArtsScience
-    case Engineering
-    case ILR
-    case CALS
-    case Hotel
-    case AAP
-    case HumanEcology
-}
-
-struct Location {
-    var longitude: Float
-    var latitude: Float
-    
-    init(longitude: Float, latitude: Float) {
-        self.longitude = longitude
-        self.latitude = latitude
-    }
-}
-
-struct Event {
-    var name: String
-    var description: String
-    var location: Location
-    var college: College
-    var type: EventType
-    var time: Date
-}
-
 struct Building {
     var college: College?
     var name: String

--- a/CampusTour/Helpers/DateHelpers.swift
+++ b/CampusTour/Helpers/DateHelpers.swift
@@ -1,0 +1,27 @@
+//
+//  DateHelpers.swift
+//  CampusTour
+//
+//  Created by Annie Cheng on 4/4/18.
+//  Copyright © 2018 cuappdev. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+    func toString(dateFormat: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        dateFormatter.timeZone = NSTimeZone(name: "EST") as TimeZone!
+        return dateFormatter.string(from: self)
+    }
+}
+
+extension String {
+    func toDate(dateFormat: String) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        dateFormatter.timeZone = NSTimeZone(name: "EST") as TimeZone!
+        return dateFormatter.date(from: self)!
+    }
+}

--- a/CampusTour/ViewControllers/ItemFeedViewController.swift
+++ b/CampusTour/ViewControllers/ItemFeedViewController.swift
@@ -21,7 +21,7 @@ struct Item {
 class ItemFeedViewController: UITableViewController {
     private let mapSection = 0, itemSection = 1, placesSection = 2
     
-    let events: [Event] = testEvents
+    var events: [Event] = testEvents
     let places: [Building] = testPlaces
     
     override func viewDidLoad() {
@@ -47,14 +47,13 @@ class ItemFeedViewController: UITableViewController {
             cell.setCellModel(
                 model: ItemOfInterestTableViewCell.ModelInfo(
                     title: item.name,
-                    dateRange: (item.time, item.time.addingTimeInterval(600)),
+                    dateRange: (item.startTime, item.endTime),
                     description: item.description,
                     locationSpec: ItemOfInterestTableViewCell.LocationLineViewSpec(locationName: "todo, add location name",
                                                                                    distanceString: "x mi away") ,
                     tags: ["tag1", "tag2"], //TODO add tags to data
                     imageUrl: URL(string: "https://picsum.photos/150/150/?random")!),
-                layout: .event
-            )
+                layout: .event)
             return cell
         case placesSection:
             let place = places[indexPath.row]


### PR DESCRIPTION
Added a Data Manager that will handle all fetching of data. For now, the data manager only fetches events but logic for fetching location data will be added later.

We should also figure out the best way to cache the data and make async calls to minimize the time it takes to fetch data. 